### PR TITLE
Support uninstalling custom paths; bump SmartGit to 21.1.1

### DIFF
--- a/package/SmartGit.nuspec
+++ b/package/SmartGit.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>smartgit</id>
-    <version>20.1.5</version>
+    <version>21.1.1</version>
     <title>SmartGit</title>
     <authors>syntevo</authors>
     <owners>sebnilsson</owners>

--- a/package/tools/chocolateyInstall.ps1
+++ b/package/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$version = '20_1_5'
+$version = '21_1_1'
 
 $packageName = 'SmartGit'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
@@ -14,7 +14,7 @@ $packageArgs = @{
     unzipLocation  = $toolsDir
     url64            = $url
 
-    checksum64       = 'B35F60AE660805E2091B821645D3C215EE66B9D1294D42E28ED416AAA517A6A8'
+    checksum64       = '3CFF55681DF7E5AA23ED52464234FB69349CDFA710A8235CDF87620F671519E3'
     checksumType64   = 'sha256'
 }
 

--- a/package/tools/chocolateyInstall.ps1
+++ b/package/tools/chocolateyInstall.ps1
@@ -1,5 +1,6 @@
 ﻿$ErrorActionPreference = 'Stop'
 
+# Todo: Use javascript in a GitHub workflow to get the URL and hash of latest download
 $version = '21_1_1'
 
 $packageName = 'SmartGit'

--- a/package/tools/chocolateyUninstall.ps1
+++ b/package/tools/chocolateyUninstall.ps1
@@ -4,11 +4,34 @@ $installerType = "exe"
 $folderName = "SmartGit"
 $uninstallFile = "unins000.exe"
 
+$key = "HKLM:\SOFTWARE\SmartGit"
+$valueName = "ApplicationIcon"
+$path = ""
+$pathExists = $false
+
 # Uninstall SmartGit if older version is installed
-if (Test-Path "$env:ProgramFiles\$folderName") {
-    Uninstall-ChocolateyPackage $packageName $installerType "/VERYSILENT /NORESTART" "$env:ProgramFiles\$folderName\$uninstallFile"
+try {
+    $path = (Get-ItemPropertyValue -Path $key -Name $valueName).replace("`"","")
+    $path = (Get-Item $path).Directory.Parent.FullName
+    $path = (Join-Path -Path $path -ChildPath $uninstallFile)
+    $pathExists = Test-Path $path
+}
+catch [System.NullArgumentException]{
+    $lastError = $Error[0]
+    Write-Warning -Message "Failed to get uninstaller's path from Registry.`n$lastError`nTrying default paths..."
+}
+catch [System.Management.Automation.RuntimeException] {
+    $lastError = $Error[0]
+    Write-Warning -Message "Failed to get uninstaller's path from Registry.`n$lastError`nTrying default paths..."
 }
 
-if (Test-Path "${env:ProgramFiles(x86)}\$folderName") {
+if (Test-Path "$env:ProgramFiles\$folderName") {
+    Uninstall-ChocolateyPackage $packageName $installerType "/VERYSILENT /NORESTART" "$env:ProgramFiles\$folderName\$uninstallFile"
+}elseif (Test-Path "${env:ProgramFiles(x86)}\$folderName") {
     Uninstall-ChocolateyPackage $packageName $installerType "/VERYSILENT /NORESTART" "${env:ProgramFiles(x86)}\$folderName\$uninstallFile"
+}elseif ($pathExists)
+{
+    Uninstall-ChocolateyPackage $packageName $installerType "/VERYSILENT /NORESTART" "$path"
+}else {
+    Write-Error -Message "No $packageName was found to uninstall."
 }

--- a/package/tools/chocolateyUninstall.ps1
+++ b/package/tools/chocolateyUninstall.ps1
@@ -4,7 +4,7 @@ $installerType = "exe"
 $folderName = "SmartGit"
 $uninstallFile = "unins000.exe"
 
-# Uninstall PDFCreator if older version is installed
+# Uninstall SmartGit if older version is installed
 if (Test-Path "$env:ProgramFiles\$folderName") {
     Uninstall-ChocolateyPackage $packageName $installerType "/VERYSILENT /NORESTART" "$env:ProgramFiles\$folderName\$uninstallFile"
 }


### PR DESCRIPTION
P.S. A javascript could be used in a GitHub Workflow to extract the latest installer's URL, Then the installer could be downloaded by the VM and hashed for the necessary sha265 checksum.
The Workflow could then be made to commit version bumps.